### PR TITLE
Move ruptures to core dependencies closes #25

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,10 +35,10 @@ dependencies = [
     "tqdm",
     "tabulate",
     "seaborn",
+    "ruptures",
 ]
 
 [project.optional-dependencies]
-ruptures = ["ruptures"]
 dev = ["pytest", "pytest-cov"]
 
 [project.urls]


### PR DESCRIPTION
Add ruptures to core dependencies so it installs automatically with the package.

Closes #25