### PR TITLE
Fix broken code examples in API docs

### DIFF
--- a/ammonyte/core/rqa_res.py
+++ b/ammonyte/core/rqa_res.py
@@ -150,32 +150,32 @@ class RQARes(Series):
 
         Complete LERM workflow:
 
-        .. jupyter-execute::
+        ```python
+        import os, ammonyte as amt
 
-            import os, ammonyte as amt
+        # Load data
+        ngrip = amt.Series.from_csv(os.path.join(os.path.dirname(amt.__file__), 'data', 'NGRIP.csv'))
 
-            # Load data
-            ngrip = amt.Series.from_csv(os.path.join(os.path.dirname(amt.__file__), 'data', 'NGRIP.csv'))
+        # LERM analysis
+        NGRIP_td = amt.TimeEmbeddedSeries(ngrip, m=11)
+        NGRIP_epsilon = NGRIP_td.find_epsilon(eps=1, target_density=0.05)
+        NGRIP_rm = NGRIP_epsilon['Output']
+        NGRIP_lp = NGRIP_rm.laplacian_eigenmaps(w_size=20, w_incre=4)
+        NGRIP_lp_smooth = amt.utils.fisher.smooth_series(NGRIP_lp, block_size=3)
 
-            # LERM analysis
-            NGRIP_td = amt.TimeEmbeddedSeries(ngrip, m=11)
-            NGRIP_epsilon = NGRIP_td.find_epsilon(eps=1, target_density=0.05)
-            NGRIP_rm = NGRIP_epsilon['Output']
-            NGRIP_lp = NGRIP_rm.laplacian_eigenmaps(w_size=20, w_incre=4)
-            NGRIP_lp_smooth = amt.utils.fisher.smooth_series(NGRIP_lp, block_size=3)
-
-            # Detect transitions
-            transitions = NGRIP_lp_smooth.lerm_transitions()
-            print(transitions)
-            transitions.plot()
+        # Detect transitions
+        transitions = NGRIP_lp_smooth.lerm_transitions()
+        print(transitions)
+        transitions.plot()
+        ```
 
         Custom confidence bounds:
 
-        .. jupyter-execute::
-
-            transitions = NGRIP_lp_smooth.lerm_transitions(
-                transition_interval=(0.025, 0.010)
-            )
+        ```python
+        transitions = NGRIP_lp_smooth.lerm_transitions(
+            transition_interval=(0.025, 0.010)
+        )
+        ```
         '''
 
         # Call the detection function from utils

--- a/ammonyte/core/series.py
+++ b/ammonyte/core/series.py
@@ -321,27 +321,27 @@ class Series(pyleo.Series):
         --------
         
         Basic tipping point detection:
-        
-        .. jupyter-execute::
-        
-            import os, ammonyte as amt
-            ngrip = amt.Series.from_csv(os.path.join(os.path.dirname(amt.__file__), 'data', 'NGRIP.csv'))
-            transitions = ngrip.kstest(w_min=0.12, w_max=2.5, n_w=15, d_c=0.77, n_c=3, s_c=2, x_c=0.8)
-            print(transitions)
-        
+
+        ```python
+        import os, ammonyte as amt
+        ngrip = amt.Series.from_csv(os.path.join(os.path.dirname(amt.__file__), 'data', 'NGRIP.csv'))
+        transitions = ngrip.kstest(w_min=0.12, w_max=2.5, n_w=15, d_c=0.77, n_c=3, s_c=2, x_c=0.8)
+        print(transitions)
+        ```
+
         Access transition statistics:
-        
-        .. jupyter-execute::
-        
-            print(f"D-statistics: {transitions.d_statistics}")
-            print(f"P-values: {transitions.p_values}")
-        
+
+        ```python
+        print(f"D-statistics: {transitions.d_statistics}")
+        print(f"P-values: {transitions.p_values}")
+        ```
+
         Plot the results:
-        
-        .. jupyter-execute::
-        
-            transitions.plot()
-        
+
+        ```python
+        transitions.plot()
+        ```
+
         See Also
         --------
         DeterministicTransitions.plot : Visualize detected transitions
@@ -449,18 +449,18 @@ class Series(pyleo.Series):
 
         Basic transition detection:
 
-        .. jupyter-execute::
-
-            import os, ammonyte as amt
-            ngrip = amt.Series.from_csv(os.path.join(os.path.dirname(amt.__file__), 'data', 'NGRIP.csv'))
-            transitions = ngrip.ruptures(algo='Pelt', cost='rbf', pen=5)
-            print(transitions)
+        ```python
+        import os, ammonyte as amt
+        ngrip = amt.Series.from_csv(os.path.join(os.path.dirname(amt.__file__), 'data', 'NGRIP.csv'))
+        transitions = ngrip.ruptures(algo='Pelt', cost='rbf', pen=5)
+        print(transitions)
+        ```
 
         Plot the results:
 
-        .. jupyter-execute::
-
-            transitions.plot()
+        ```python
+        transitions.plot()
+        ```
 
 
         References

--- a/ammonyte/core/transitions.py
+++ b/ammonyte/core/transitions.py
@@ -57,27 +57,27 @@ class DeterministicTransitions:
     --------
     
     Basic transition detection:
-    
-    .. jupyter-execute::
-    
-        import os, ammonyte as amt
-        ngrip = amt.Series.from_csv(os.path.join(os.path.dirname(amt.__file__), 'data', 'NGRIP.csv'))
-        transitions = ngrip.kstest(w_min=0.12, w_max=2.5, n_w=15, d_c=0.77, n_c=3, s_c=2, x_c=0.8)
-        print(transitions)
-        
+
+    ```python
+    import os, ammonyte as amt
+    ngrip = amt.Series.from_csv(os.path.join(os.path.dirname(amt.__file__), 'data', 'NGRIP.csv'))
+    transitions = ngrip.kstest(w_min=0.12, w_max=2.5, n_w=15, d_c=0.77, n_c=3, s_c=2, x_c=0.8)
+    print(transitions)
+    ```
+
     Plot the results:
-    
-    .. jupyter-execute::
-    
-        transitions.plot()
-        
+
+    ```python
+    transitions.plot()
+    ```
+
     Access transition data:
-    
-    .. jupyter-execute::
-    
-        print(f"Number of transitions: {len(transitions.jump_times)}")
-        print(f"First transition: {transitions.jump_times[0]:.2f}")
-    
+
+    ```python
+    print(f"Number of transitions: {len(transitions.jump_times)}")
+    print(f"First transition: {transitions.jump_times[0]:.2f}")
+    ```
+
     See Also
     --------
     Series.kstest : Detect transitions

--- a/ammonyte/utils/ks.py
+++ b/ammonyte/utils/ks.py
@@ -66,17 +66,17 @@ def KS_test(series, w_min, w_max, n_w, d_c, n_c, s_c, x_c=None):
     
     Examples
     --------
-    
+
     Basic usage (typically called via Series.kstest):
-    
-    .. jupyter-execute::
-    
-        import os, ammonyte as amt
-        from ammonyte.utils.ks import KS_test
-        ngrip = amt.Series.from_csv(os.path.join(os.path.dirname(amt.__file__), 'data', 'NGRIP.csv'))
-        transitions = KS_test(ngrip, w_min=0.12, w_max=2.5, n_w=15, d_c=0.77, n_c=3, s_c=2.0, x_c=0.8)
-        print(f"Detected {len(transitions[0])} transitions")
-    
+
+    ```python
+    import os, ammonyte as amt
+    from ammonyte.utils.ks import KS_test
+    ngrip = amt.Series.from_csv(os.path.join(os.path.dirname(amt.__file__), 'data', 'NGRIP.csv'))
+    transitions = KS_test(ngrip, w_min=0.12, w_max=2.5, n_w=15, d_c=0.77, n_c=3, s_c=2.0, x_c=0.8)
+    print(f"Detected {len(transitions[0])} transitions")
+    ```
+
     See Also
     --------
     Series.kstest : High-level interface to this function

--- a/ammonyte/utils/lerm_transitions.py
+++ b/ammonyte/utils/lerm_transitions.py
@@ -72,23 +72,23 @@ def lerm_transition(series, transition_interval=None,
 
     Basic usage (typically called via Series.lerm_transitions):
 
-    .. jupyter-execute::
+    ```python
+    import os, ammonyte as amt
+    from ammonyte.utils.lerm_transitions import lerm_transition
 
-        import os, ammonyte as amt
-        from ammonyte.utils.lerm_transitions import lerm_transition
+    # Load data and perform LERM analysis
+    ngrip = amt.Series.from_csv(os.path.join(os.path.dirname(amt.__file__), 'data', 'NGRIP.csv'))
+    NGRIP_td = amt.TimeEmbeddedSeries(ngrip, m=11)
+    NGRIP_epsilon = NGRIP_td.find_epsilon(eps=1, target_density=0.05)
+    NGRIP_rm = NGRIP_epsilon['Output']
+    NGRIP_lp = NGRIP_rm.laplacian_eigenmaps(w_size=20, w_incre=4)
+    NGRIP_lp_smooth = amt.utils.fisher.smooth_series(NGRIP_lp, block_size=3)
 
-        # Load data and perform LERM analysis
-        ngrip = amt.Series.from_csv(os.path.join(os.path.dirname(amt.__file__), 'data', 'NGRIP.csv'))
-        NGRIP_td = amt.TimeEmbeddedSeries(ngrip, m=11)
-        NGRIP_epsilon = NGRIP_td.find_epsilon(eps=1, target_density=0.05)
-        NGRIP_rm = NGRIP_epsilon['Output']
-        NGRIP_lp = NGRIP_rm.laplacian_eigenmaps(w_size=20, w_incre=4)
-        NGRIP_lp_smooth = amt.utils.fisher.smooth_series(NGRIP_lp, block_size=3)
-
-        # Detect transitions
-        jump_times, jump_directions, upper_bound, lower_bound = lerm_transition(NGRIP_lp_smooth)
-        print(f"Detected {len(jump_times)} transitions")
-        print(f"Bounds used: upper={upper_bound:.4f}, lower={lower_bound:.4f}")
+    # Detect transitions
+    jump_times, jump_directions, upper_bound, lower_bound = lerm_transition(NGRIP_lp_smooth)
+    print(f"Detected {len(jump_times)} transitions")
+    print(f"Bounds used: upper={upper_bound:.4f}, lower={lower_bound:.4f}")
+    ```
 
     See Also
     --------

--- a/ammonyte/utils/metrics.py
+++ b/ammonyte/utils/metrics.py
@@ -163,30 +163,30 @@ def evaluate_detection(detected, ground_truth, tolerance=0.5):
 
     Basic usage:
 
-    .. jupyter-execute::
+    ```python
+    from ammonyte.utils.metrics import evaluate_detection
 
-        from ammonyte.utils.metrics import evaluate_detection
+    detected = [10, 25, 50, 75]
+    ground_truth = [10, 26, 60]
 
-        detected = [10, 25, 50, 75]
-        ground_truth = [10, 26, 60]
-
-        metrics = evaluate_detection(detected, ground_truth, tolerance=2)
-        print(metrics)
+    metrics = evaluate_detection(detected, ground_truth, tolerance=2)
+    print(metrics)
+    ```
 
     Access individual metrics:
 
-    .. jupyter-execute::
+    ```python
+    from ammonyte.utils.metrics import evaluate_detection
 
-        from ammonyte.utils.metrics import evaluate_detection
+    detected = [9.8, 23.5, 45.2]
+    ground_truth = [10, 25, 40, 60]
 
-        detected = [9.8, 23.5, 45.2]
-        ground_truth = [10, 25, 40, 60]
+    metrics = evaluate_detection(detected, ground_truth, tolerance=1.0)
 
-        metrics = evaluate_detection(detected, ground_truth, tolerance=1.0)
-
-        print(f"Precision: {metrics.precision:.3f}")
-        print(f"Recall: {metrics.recall:.3f}")
-        print(f"F1 Score: {metrics.f1_score:.3f}")
+    print(f"Precision: {metrics.precision:.3f}")
+    print(f"Recall: {metrics.recall:.3f}")
+    print(f"F1 Score: {metrics.f1_score:.3f}")
+    ```
 
     '''
     detected = np.asarray(detected)

--- a/ammonyte/utils/ruptures_transitions.py
+++ b/ammonyte/utils/ruptures_transitions.py
@@ -103,13 +103,13 @@ def ruptures_transition(series, algo='Pelt', cost='rbf', pen=None, n_bkps=None,
 
     Basic usage (typically called via Series.ruptures):
 
-    .. jupyter-execute::
-
-        import os, ammonyte as amt
-        from ammonyte.utils.ruptures_transitions import ruptures_transition
-        ngrip = amt.Series.from_csv(os.path.join(os.path.dirname(amt.__file__), 'data', 'NGRIP.csv'))
-        transitions = ngrip.ruptures(algo='Pelt', cost='rbf', pen=5)
-        print(f"Detected {len(transitions.jump_times)} transitions")
+    ```python
+    import os, ammonyte as amt
+    from ammonyte.utils.ruptures_transitions import ruptures_transition
+    ngrip = amt.Series.from_csv(os.path.join(os.path.dirname(amt.__file__), 'data', 'NGRIP.csv'))
+    transitions = ngrip.ruptures(algo='Pelt', cost='rbf', pen=5)
+    print(f"Detected {len(transitions.jump_times)} transitions")
+    ```
 
     See Also
     --------

--- a/docs/api/core.rqa_res.RQARes.qmd
+++ b/docs/api/core.rqa_res.RQARes.qmd
@@ -318,32 +318,32 @@ obtained from LERM analysis, typically after smoothing.
 
 Complete LERM workflow:
 
-.. jupyter-execute::
+```python
+import os, ammonyte as amt
 
-    import os, ammonyte as amt
+# Load data
+ngrip = amt.Series.from_csv(os.path.join(os.path.dirname(amt.__file__), 'data', 'NGRIP.csv'))
 
-    # Load data
-    ngrip = amt.Series.from_csv(os.path.join(os.path.dirname(amt.__file__), 'data', 'NGRIP.csv'))
+# LERM analysis
+NGRIP_td = amt.TimeEmbeddedSeries(ngrip, m=11)
+NGRIP_epsilon = NGRIP_td.find_epsilon(eps=1, target_density=0.05)
+NGRIP_rm = NGRIP_epsilon['Output']
+NGRIP_lp = NGRIP_rm.laplacian_eigenmaps(w_size=20, w_incre=4)
+NGRIP_lp_smooth = amt.utils.fisher.smooth_series(NGRIP_lp, block_size=3)
 
-    # LERM analysis
-    NGRIP_td = amt.TimeEmbeddedSeries(ngrip, m=11)
-    NGRIP_epsilon = NGRIP_td.find_epsilon(eps=1, target_density=0.05)
-    NGRIP_rm = NGRIP_epsilon['Output']
-    NGRIP_lp = NGRIP_rm.laplacian_eigenmaps(w_size=20, w_incre=4)
-    NGRIP_lp_smooth = amt.utils.fisher.smooth_series(NGRIP_lp, block_size=3)
-
-    # Detect transitions
-    transitions = NGRIP_lp_smooth.lerm_transitions()
-    print(transitions)
-    transitions.plot()
+# Detect transitions
+transitions = NGRIP_lp_smooth.lerm_transitions()
+print(transitions)
+transitions.plot()
+```
 
 Custom confidence bounds:
 
-.. jupyter-execute::
-
-    transitions = NGRIP_lp_smooth.lerm_transitions(
-        transition_interval=(0.025, 0.010)
-    )
+```python
+transitions = NGRIP_lp_smooth.lerm_transitions(
+    transition_interval=(0.025, 0.010)
+)
+```
 
 ### plot_eigenmaps { #ammonyte.core.rqa_res.RQARes.plot_eigenmaps }
 

--- a/docs/api/core.series.Series.qmd
+++ b/docs/api/core.series.Series.qmd
@@ -174,25 +174,25 @@ Applies sliding window KS test to detect abrupt transitions in time series data 
 
 Basic tipping point detection:
 
-.. jupyter-execute::
-
-    import os, ammonyte as amt
-    ngrip = amt.Series.from_csv(os.path.join(os.path.dirname(amt.__file__), 'data', 'NGRIP.csv'))
-    transitions = ngrip.kstest(w_min=0.12, w_max=2.5, n_w=15, d_c=0.77, n_c=3, s_c=2, x_c=0.8)
-    print(transitions)
+```python
+import os, ammonyte as amt
+ngrip = amt.Series.from_csv(os.path.join(os.path.dirname(amt.__file__), 'data', 'NGRIP.csv'))
+transitions = ngrip.kstest(w_min=0.12, w_max=2.5, n_w=15, d_c=0.77, n_c=3, s_c=2, x_c=0.8)
+print(transitions)
+```
 
 Access transition statistics:
 
-.. jupyter-execute::
-
-    print(f"D-statistics: {transitions.d_statistics}")
-    print(f"P-values: {transitions.p_values}")
+```python
+print(f"D-statistics: {transitions.d_statistics}")
+print(f"P-values: {transitions.p_values}")
+```
 
 Plot the results:
 
-.. jupyter-execute::
-
-    transitions.plot()
+```python
+transitions.plot()
+```
 
 #### See Also {.doc-section .doc-section-see-also}
 
@@ -315,18 +315,18 @@ Applies ruptures algorithms for offline change point detection.
 
 Basic transition detection:
 
-.. jupyter-execute::
-
-    import os, ammonyte as amt
-    ngrip = amt.Series.from_csv(os.path.join(os.path.dirname(amt.__file__), 'data', 'NGRIP.csv'))
-    transitions = ngrip.ruptures(algo='Pelt', cost='rbf', pen=5)
-    print(transitions)
+```python
+import os, ammonyte as amt
+ngrip = amt.Series.from_csv(os.path.join(os.path.dirname(amt.__file__), 'data', 'NGRIP.csv'))
+transitions = ngrip.ruptures(algo='Pelt', cost='rbf', pen=5)
+print(transitions)
+```
 
 Plot the results:
 
-.. jupyter-execute::
-
-    transitions.plot()
+```python
+transitions.plot()
+```
 
 #### References {.doc-section .doc-section-references}
 

--- a/docs/api/core.transitions.DeterministicTransitions.qmd
+++ b/docs/api/core.transitions.DeterministicTransitions.qmd
@@ -54,25 +54,25 @@ Stores results from tipping point detection algorithms with methods for analysis
 
 Basic transition detection:
 
-.. jupyter-execute::
+```python
+import os, ammonyte as amt
+ngrip = amt.Series.from_csv(os.path.join(os.path.dirname(amt.__file__), 'data', 'NGRIP.csv'))
+transitions = ngrip.kstest(w_min=0.12, w_max=2.5, n_w=15, d_c=0.77, n_c=3, s_c=2, x_c=0.8)
+print(transitions)
+```
 
-    import os, ammonyte as amt
-    ngrip = amt.Series.from_csv(os.path.join(os.path.dirname(amt.__file__), 'data', 'NGRIP.csv'))
-    transitions = ngrip.kstest(w_min=0.12, w_max=2.5, n_w=15, d_c=0.77, n_c=3, s_c=2, x_c=0.8)
-    print(transitions)
-    
 Plot the results:
 
-.. jupyter-execute::
+```python
+transitions.plot()
+```
 
-    transitions.plot()
-    
 Access transition data:
 
-.. jupyter-execute::
-
-    print(f"Number of transitions: {len(transitions.jump_times)}")
-    print(f"First transition: {transitions.jump_times[0]:.2f}")
+```python
+print(f"Number of transitions: {len(transitions.jump_times)}")
+print(f"First transition: {transitions.jump_times[0]:.2f}")
+```
 
 ## See Also {.doc-section .doc-section-see-also}
 

--- a/docs/api/utils.ks.KS_test.qmd
+++ b/docs/api/utils.ks.KS_test.qmd
@@ -60,13 +60,13 @@ Applies sliding window KS test to detect abrupt transitions using the method of 
 
 Basic usage (typically called via Series.kstest):
 
-.. jupyter-execute::
-
-    import os, ammonyte as amt
-    from ammonyte.utils.ks import KS_test
-    ngrip = amt.Series.from_csv(os.path.join(os.path.dirname(amt.__file__), 'data', 'NGRIP.csv'))
-    transitions = KS_test(ngrip, w_min=0.12, w_max=2.5, n_w=15, d_c=0.77, n_c=3, s_c=2.0, x_c=0.8)
-    print(f"Detected {len(transitions[0])} transitions")
+```python
+import os, ammonyte as amt
+from ammonyte.utils.ks import KS_test
+ngrip = amt.Series.from_csv(os.path.join(os.path.dirname(amt.__file__), 'data', 'NGRIP.csv'))
+transitions = KS_test(ngrip, w_min=0.12, w_max=2.5, n_w=15, d_c=0.77, n_c=3, s_c=2.0, x_c=0.8)
+print(f"Detected {len(transitions[0])} transitions")
+```
 
 ## See Also {.doc-section .doc-section-see-also}
 

--- a/docs/api/utils.lerm_transitions.lerm_transition.qmd
+++ b/docs/api/utils.lerm_transitions.lerm_transition.qmd
@@ -65,23 +65,23 @@ dynamical system.
 
 Basic usage (typically called via Series.lerm_transitions):
 
-.. jupyter-execute::
+```python
+import os, ammonyte as amt
+from ammonyte.utils.lerm_transitions import lerm_transition
 
-    import os, ammonyte as amt
-    from ammonyte.utils.lerm_transitions import lerm_transition
+# Load data and perform LERM analysis
+ngrip = amt.Series.from_csv(os.path.join(os.path.dirname(amt.__file__), 'data', 'NGRIP.csv'))
+NGRIP_td = amt.TimeEmbeddedSeries(ngrip, m=11)
+NGRIP_epsilon = NGRIP_td.find_epsilon(eps=1, target_density=0.05)
+NGRIP_rm = NGRIP_epsilon['Output']
+NGRIP_lp = NGRIP_rm.laplacian_eigenmaps(w_size=20, w_incre=4)
+NGRIP_lp_smooth = amt.utils.fisher.smooth_series(NGRIP_lp, block_size=3)
 
-    # Load data and perform LERM analysis
-    ngrip = amt.Series.from_csv(os.path.join(os.path.dirname(amt.__file__), 'data', 'NGRIP.csv'))
-    NGRIP_td = amt.TimeEmbeddedSeries(ngrip, m=11)
-    NGRIP_epsilon = NGRIP_td.find_epsilon(eps=1, target_density=0.05)
-    NGRIP_rm = NGRIP_epsilon['Output']
-    NGRIP_lp = NGRIP_rm.laplacian_eigenmaps(w_size=20, w_incre=4)
-    NGRIP_lp_smooth = amt.utils.fisher.smooth_series(NGRIP_lp, block_size=3)
-
-    # Detect transitions
-    jump_times, jump_directions, upper_bound, lower_bound = lerm_transition(NGRIP_lp_smooth)
-    print(f"Detected {len(jump_times)} transitions")
-    print(f"Bounds used: upper={upper_bound:.4f}, lower={lower_bound:.4f}")
+# Detect transitions
+jump_times, jump_directions, upper_bound, lower_bound = lerm_transition(NGRIP_lp_smooth)
+print(f"Detected {len(jump_times)} transitions")
+print(f"Bounds used: upper={upper_bound:.4f}, lower={lower_bound:.4f}")
+```
 
 ## See Also {.doc-section .doc-section-see-also}
 

--- a/docs/api/utils.metrics.evaluate_detection.qmd
+++ b/docs/api/utils.metrics.evaluate_detection.qmd
@@ -35,27 +35,27 @@ one detected point.
 
 Basic usage:
 
-.. jupyter-execute::
+```python
+from ammonyte.utils.metrics import evaluate_detection
 
-    from ammonyte.utils.metrics import evaluate_detection
+detected = [10, 25, 50, 75]
+ground_truth = [10, 26, 60]
 
-    detected = [10, 25, 50, 75]
-    ground_truth = [10, 26, 60]
-
-    metrics = evaluate_detection(detected, ground_truth, tolerance=2)
-    print(metrics)
+metrics = evaluate_detection(detected, ground_truth, tolerance=2)
+print(metrics)
+```
 
 Access individual metrics:
 
-.. jupyter-execute::
+```python
+from ammonyte.utils.metrics import evaluate_detection
 
-    from ammonyte.utils.metrics import evaluate_detection
+detected = [9.8, 23.5, 45.2]
+ground_truth = [10, 25, 40, 60]
 
-    detected = [9.8, 23.5, 45.2]
-    ground_truth = [10, 25, 40, 60]
+metrics = evaluate_detection(detected, ground_truth, tolerance=1.0)
 
-    metrics = evaluate_detection(detected, ground_truth, tolerance=1.0)
-
-    print(f"Precision: {metrics.precision:.3f}")
-    print(f"Recall: {metrics.recall:.3f}")
-    print(f"F1 Score: {metrics.f1_score:.3f}")
+print(f"Precision: {metrics.precision:.3f}")
+print(f"Recall: {metrics.recall:.3f}")
+print(f"F1 Score: {metrics.f1_score:.3f}")
+```

--- a/docs/api/utils.ruptures_transitions.ruptures_transition.qmd
+++ b/docs/api/utils.ruptures_transitions.ruptures_transition.qmd
@@ -73,13 +73,13 @@ See interp, bin, and gkernel methods in parent class pyleoclim.Series for detail
 
 Basic usage (typically called via Series.ruptures):
 
-.. jupyter-execute::
-
-    import os, ammonyte as amt
-    from ammonyte.utils.ruptures_transitions import ruptures_transition
-    ngrip = amt.Series.from_csv(os.path.join(os.path.dirname(amt.__file__), 'data', 'NGRIP.csv'))
-    transitions = ngrip.ruptures(algo='Pelt', cost='rbf', pen=5)
-    print(f"Detected {len(transitions.jump_times)} transitions")
+```python
+import os, ammonyte as amt
+from ammonyte.utils.ruptures_transitions import ruptures_transition
+ngrip = amt.Series.from_csv(os.path.join(os.path.dirname(amt.__file__), 'data', 'NGRIP.csv'))
+transitions = ngrip.ruptures(algo='Pelt', cost='rbf', pen=5)
+print(f"Detected {len(transitions.jump_times)} transitions")
+```
 
 ## See Also {.doc-section .doc-section-see-also}
 


### PR DESCRIPTION
Docstring examples used `.. jupyter-execute::`, a Sphinx-only directive that Quarto/quartodoc doesn't understand — it rendered as broken plain text instead of a code block. Replaced with plain fenced ```python blocks ```
